### PR TITLE
DEVOPS-247: RDS snapshot rotation not working

### DIFF
--- a/bin/rds-rotate-db-snapshots
+++ b/bin/rds-rotate-db-snapshots
@@ -39,24 +39,24 @@ end
 def rotate_em(snapshots)
   # poor man's way to get a deep copy of our time_periods definition hash
   periods = Marshal.load(Marshal.dump($time_periods))
-  
+
   snapshots.each do |snapshot|
     time = snapshot[:snapshot_create_time]
     db_id = snapshot[:db_instance_identifier]
     snapshot_id = snapshot[:db_snapshot_identifier]
     description = snapshot_id
     keep_reason = nil
-    
+
     if $opts[:pattern] && description !~ /#{$opts[:pattern]}/
       puts "  #{time.strftime '%Y-%m-%d %H:%M:%S'} #{snapshot_id} Skipping snapshot with description #{description}"
       next
     end
-    
+
     periods.keys.sort { |a, b| periods[a][:seconds] <=> periods[b][:seconds] }.each do |period|
       period_info = periods[period]
       keep = period_info[:keep]
       keeping = period_info[:keeping]
-      
+
       time_string = time.strftime period_info[:format]
       if Time.now - time < keep * period_info[:seconds]
         if !keeping.key?(time_string) && keeping.length < keep
@@ -66,11 +66,11 @@ def rotate_em(snapshots)
         break
       end
     end
-    
+
     if keep_reason.nil? && snapshot == snapshots.last && $opts[:keep_last]
       keep_reason = 'last snapshot'
     end
-    
+
     if !keep_reason.nil?
       puts "  #{time.strftime '%Y-%m-%d %H:%M:%S'} #{snapshot_id} Keeping for #{keep_reason}"
     else
@@ -115,6 +115,18 @@ def split_tag(hash,v)
         end
         hash[tag] = value
     end
+end
+
+def get_db_snapshots(options)
+  snapshots = []
+  response = $rds.describe_db_snapshots(options)
+  while true do
+    snapshots += response.db_snapshots
+    break unless response[:marker]
+
+    response = $rds.describe_db_snapshots(options.merge(marker: response[:marker]))
+  end
+  snapshots
 end
 
 OptionParser.new do |o|
@@ -247,8 +259,8 @@ if $opts[:by_tags]
   end
 
   begin
-    rotate_these = $rds.describe_db_snapshots(db_instance_identifier: all_snapshots.map(&:db_instance_identifier).uniq).
-      db_snapshots.delete_if{ |e| !all_snapshots.include?(e.db_snapshot_identifier) }.
+    rotate_these = get_db_snapshots(db_instance_identifier: all_snapshots.map(&:db_instance_identifier).uniq).
+      delete_if{ |e| !all_snapshots.include?(e.db_snapshot_identifier) }.
       sort {|a,b| a[:snapshot_create_time] <=> b[:snapshot_create_time] }
   rescue AWS::RDS::Errors => e
     backoff()
@@ -258,7 +270,7 @@ if $opts[:by_tags]
   rotate_em(rotate_these)
 else
   begin
-    all_snapshots = $rds.describe_db_snapshots(snapshot_type: 'manual').db_snapshots.
+    all_snapshots = get_db_snapshots(snapshot_type: 'manual').
       delete_if{ |e| e.status != 'available' }
   rescue AWS::RDS::Errors => e
     backoff()


### PR DESCRIPTION
rds-rotate-db-snapshots doesn't iterate through results when calling describe-db-snapshots, instead it only grabs the first set which maxxes out at 100 snapshots. This explains why snapshot rotation isn't working correctly.

Changes: iterate through results so they're all fetched correctly.