### PR TITLE
DEVOPS-247: Fix access to status (hash not method)

### DIFF
--- a/bin/rds-rotate-db-snapshots
+++ b/bin/rds-rotate-db-snapshots
@@ -271,7 +271,7 @@ if $opts[:by_tags]
 else
   begin
     all_snapshots = get_db_snapshots(snapshot_type: 'manual').
-      delete_if{ |e| e.status != 'available' }
+      delete_if{ |e| e[:status] != 'available' }
   rescue AWS::RDS::Errors => e
     backoff()
     retry


### PR DESCRIPTION
Now need to access a snapshot's status by hash rather than method.

[Aha! Feature](https://big.aha.io/features/DEVOPS-247)