### PR TITLE
A-10061: Upgrade json gem to 2.3.0+ for security

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem 'aws-sdk', '>= 1.51.0', '< 2.0'
+gem 'aws-sdk', '~> 3'
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.


### PR DESCRIPTION
Updating json to 2.3.0+ requires updating aws-sdk which this gem uses.

Changes: update to use aws-sdk v3