### PR TITLE
A-10061-1: Update rds-rotate-db-snapshots gem to use aws-sdk v3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem 'aws-sdk-rds', '~> 1.83'
+gem 'aws-sdk-rds', '~> 1'
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem 'aws-sdk', '~> 3'
+gem 'aws-sdk-rds', '~> 1.83'
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem 'aws-sdk', '>= 1.51.0', '< 2.0'
+gem 'aws-sdk', '~> 3'
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.

--- a/bin/rds-rotate-db-snapshots
+++ b/bin/rds-rotate-db-snapshots
@@ -94,7 +94,7 @@ def create_snapshot(name, db_indentifier_ids)
         begin
           $rds.create_db_snapshot(db_snapshot_identifier: name, db_instance_identifier: db_id) unless $opts[:dry_run]
           puts "  #{Time.now.strftime '%Y-%m-%d %H:%M:%S'} Creation snapshot #{name} is pending (db: #{db_id})"
-        rescue Aws::RDS::Errors::InvalidDBInstanceState => e
+        rescue Aws::RDS::Errors::InvalidDBInstanceStateFault => e
           backoff()
           retry
         end

--- a/bin/rds-rotate-db-snapshots
+++ b/bin/rds-rotate-db-snapshots
@@ -221,8 +221,13 @@ end
 
 $backoffed = 0
 begin
-  AWS.config(access_key_id: $opts[:aws_access_key], secret_access_key: $opts[:aws_secret_access_key], region: $opts[:aws_region], session_token: $opts[:aws_session_token])
-  $rds = AWS.rds.client
+  Aws.config.update(
+    access_key_id: $opts[:aws_access_key],
+    secret_access_key: $opts[:aws_secret_access_key],
+    region: $opts[:aws_region],
+    session_token: $opts[:aws_session_token]
+  )
+  $rds = Aws::RDS::Client.new
 rescue Aws::RDS::Errors => e
   backoff()
   retry

--- a/bin/rds-rotate-db-snapshots
+++ b/bin/rds-rotate-db-snapshots
@@ -77,7 +77,7 @@ def rotate_em(snapshots)
       puts "  #{time.strftime '%Y-%m-%d %H:%M:%S'} #{snapshot_id} Deleting"
       begin
         $rds.delete_db_snapshot(db_snapshot_identifier: snapshot_id) unless $opts[:dry_run]
-      rescue AWS::RDS::Errors => e
+      rescue Aws::RDS::Errors => e
         backoff()
         retry
       end
@@ -94,7 +94,7 @@ def create_snapshot(name, db_indentifier_ids)
         begin
           $rds.create_db_snapshot(db_snapshot_identifier: name, db_instance_identifier: db_id) unless $opts[:dry_run]
           puts "  #{Time.now.strftime '%Y-%m-%d %H:%M:%S'} Creation snapshot #{name} is pending (db: #{db_id})"
-        rescue AWS::RDS::Errors::InvalidDBInstanceState => e
+        rescue Aws::RDS::Errors::InvalidDBInstanceState => e
           backoff()
           retry
         end
@@ -223,7 +223,7 @@ $backoffed = 0
 begin
   AWS.config(access_key_id: $opts[:aws_access_key], secret_access_key: $opts[:aws_secret_access_key], region: $opts[:aws_region], session_token: $opts[:aws_session_token])
   $rds = AWS.rds.client
-rescue AWS::RDS::Errors => e
+rescue Aws::RDS::Errors => e
   backoff()
   retry
 end
@@ -238,7 +238,7 @@ if $opts[:by_tags]
     begin
       these_snapshots = $rds.describe_tags(snapshot_type: 'manual', filters: {'resource-type'=>"snapshot", 'key'=>tag, 'value'=>value}).
         delete_if{ |e| e.status != 'available' }
-    rescue AWS::RDS::Errors => e
+    rescue Aws::RDS::Errors => e
       backoff()
       retry
     end
@@ -262,7 +262,7 @@ if $opts[:by_tags]
     rotate_these = get_db_snapshots(db_instance_identifier: all_snapshots.map(&:db_instance_identifier).uniq).
       delete_if{ |e| !all_snapshots.include?(e.db_snapshot_identifier) }.
       sort {|a,b| a[:snapshot_create_time] <=> b[:snapshot_create_time] }
-  rescue AWS::RDS::Errors => e
+  rescue Aws::RDS::Errors => e
     backoff()
     retry
   end
@@ -272,7 +272,7 @@ else
   begin
     all_snapshots = get_db_snapshots(snapshot_type: 'manual').
       delete_if{ |e| e[:status] != 'available' }
-  rescue AWS::RDS::Errors => e
+  rescue Aws::RDS::Errors => e
     backoff()
     retry
   end

--- a/bin/rds-rotate-db-snapshots
+++ b/bin/rds-rotate-db-snapshots
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'rubygems'
-require 'aws-sdk'
+require 'aws-sdk-rds'
 require 'optparse'
 
 $opts = {

--- a/rds-rotate-db-snapshots.gemspec
+++ b/rds-rotate-db-snapshots.gemspec
@@ -42,18 +42,18 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<aws-sdk>.freeze, ["~> 3"])
+      s.add_runtime_dependency(%q<aws-sdk-rds>.freeze, ["~> 1.83"])
       s.add_development_dependency(%q<bundler>.freeze, [">= 0"])
       s.add_development_dependency(%q<simplecov>.freeze, [">= 0"])
       s.add_development_dependency(%q<jeweler>.freeze, [">= 0"])
     else
-      s.add_dependency(%q<aws-sdk>.freeze, ["~> 3"])
+      s.add_dependency(%q<aws-sdk-rds>.freeze, ["~> 1.83"])
       s.add_dependency(%q<bundler>.freeze, [">= 0"])
       s.add_dependency(%q<simplecov>.freeze, [">= 0"])
       s.add_dependency(%q<jeweler>.freeze, [">= 0"])
     end
   else
-    s.add_dependency(%q<aws-sdk>.freeze, ["~> 3"])
+    s.add_dependency(%q<aws-sdk-rds>.freeze, ["~> 1.83"])
     s.add_dependency(%q<bundler>.freeze, [">= 0"])
     s.add_dependency(%q<simplecov>.freeze, [">= 0"])
     s.add_dependency(%q<jeweler>.freeze, [">= 0"])

--- a/rds-rotate-db-snapshots.gemspec
+++ b/rds-rotate-db-snapshots.gemspec
@@ -42,18 +42,18 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<aws-sdk-rds>.freeze, ["~> 1.83"])
+      s.add_runtime_dependency(%q<aws-sdk-rds>.freeze, ["~> 1"])
       s.add_development_dependency(%q<bundler>.freeze, [">= 0"])
       s.add_development_dependency(%q<simplecov>.freeze, [">= 0"])
       s.add_development_dependency(%q<jeweler>.freeze, [">= 0"])
     else
-      s.add_dependency(%q<aws-sdk-rds>.freeze, ["~> 1.83"])
+      s.add_dependency(%q<aws-sdk-rds>.freeze, ["~> 1"])
       s.add_dependency(%q<bundler>.freeze, [">= 0"])
       s.add_dependency(%q<simplecov>.freeze, [">= 0"])
       s.add_dependency(%q<jeweler>.freeze, [">= 0"])
     end
   else
-    s.add_dependency(%q<aws-sdk-rds>.freeze, ["~> 1.83"])
+    s.add_dependency(%q<aws-sdk-rds>.freeze, ["~> 1"])
     s.add_dependency(%q<bundler>.freeze, [">= 0"])
     s.add_dependency(%q<simplecov>.freeze, [">= 0"])
     s.add_dependency(%q<jeweler>.freeze, [">= 0"])

--- a/rds-rotate-db-snapshots.gemspec
+++ b/rds-rotate-db-snapshots.gemspec
@@ -5,16 +5,16 @@
 # stub: rds-rotate-db-snapshots 0.3.1 ruby lib
 
 Gem::Specification.new do |s|
-  s.name = "rds-rotate-db-snapshots"
+  s.name = "rds-rotate-db-snapshots".freeze
   s.version = "0.3.1"
 
-  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.require_paths = ["lib"]
-  s.authors = ["Siarhei Kavaliou"]
-  s.date = "2015-07-30"
-  s.description = "Provides a simple way to rotate RDS DB snapshots with configurable retention periods."
-  s.email = "kovserg@gmail.com"
-  s.executables = ["rds-rotate-db-snapshots"]
+  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib".freeze]
+  s.authors = ["Siarhei Kavaliou".freeze]
+  s.date = "2020-05-29"
+  s.description = "Provides a simple way to rotate RDS DB snapshots with configurable retention periods.".freeze
+  s.email = "kovserg@gmail.com".freeze
+  s.executables = ["rds-rotate-db-snapshots".freeze]
   s.extra_rdoc_files = [
     "LICENSE.txt",
     "README.rdoc"
@@ -33,30 +33,30 @@ Gem::Specification.new do |s|
     "test/helper.rb",
     "test/test_rds-rotate-db-snapshots.rb"
   ]
-  s.homepage = "http://github.com/serg-kovalev/rds-rotate-db-snapshots"
-  s.licenses = ["MIT"]
-  s.rubygems_version = "2.2.2"
-  s.summary = "Amazon RDS DB snapshot rotator"
+  s.homepage = "http://github.com/serg-kovalev/rds-rotate-db-snapshots".freeze
+  s.licenses = ["MIT".freeze]
+  s.rubygems_version = "2.7.9".freeze
+  s.summary = "Amazon RDS DB snapshot rotator".freeze
 
   if s.respond_to? :specification_version then
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<aws-sdk>, ["< 2.0", ">= 1.51.0"])
-      s.add_development_dependency(%q<bundler>, [">= 0"])
-      s.add_development_dependency(%q<simplecov>, [">= 0"])
-      s.add_development_dependency(%q<jeweler>, [">= 0"])
+      s.add_runtime_dependency(%q<aws-sdk>.freeze, ["~> 3"])
+      s.add_development_dependency(%q<bundler>.freeze, [">= 0"])
+      s.add_development_dependency(%q<simplecov>.freeze, [">= 0"])
+      s.add_development_dependency(%q<jeweler>.freeze, [">= 0"])
     else
-      s.add_dependency(%q<aws-sdk>, ["< 2.0", ">= 1.51.0"])
-      s.add_dependency(%q<bundler>, [">= 0"])
-      s.add_dependency(%q<simplecov>, [">= 0"])
-      s.add_dependency(%q<jeweler>, [">= 0"])
+      s.add_dependency(%q<aws-sdk>.freeze, ["~> 3"])
+      s.add_dependency(%q<bundler>.freeze, [">= 0"])
+      s.add_dependency(%q<simplecov>.freeze, [">= 0"])
+      s.add_dependency(%q<jeweler>.freeze, [">= 0"])
     end
   else
-    s.add_dependency(%q<aws-sdk>, ["< 2.0", ">= 1.51.0"])
-    s.add_dependency(%q<bundler>, [">= 0"])
-    s.add_dependency(%q<simplecov>, [">= 0"])
-    s.add_dependency(%q<jeweler>, [">= 0"])
+    s.add_dependency(%q<aws-sdk>.freeze, ["~> 3"])
+    s.add_dependency(%q<bundler>.freeze, [">= 0"])
+    s.add_dependency(%q<simplecov>.freeze, [">= 0"])
+    s.add_dependency(%q<jeweler>.freeze, [">= 0"])
   end
 end
 


### PR DESCRIPTION
Update aws-sdk to v3 which uses an acceptable version of the json gem.

* [Sentry error]()